### PR TITLE
Fix: Handle case for /drops if user has DMs closed

### DIFF
--- a/commands/drop.py
+++ b/commands/drop.py
@@ -26,8 +26,11 @@ async def slash_drops(ctx:SlashContext):
     description=drops_list,
     color=discord.Color.blue()
   )
-  await ctx.author.send(embed=embed)
-  await ctx.reply("<:tendi_smile_happy:757768236069814283> Sent you a DM with the full List of Drops!", hidden=True)
+  try:
+    await ctx.author.send(embed=embed)
+    await ctx.reply("<:tendi_smile_happy:757768236069814283> Sent you a DM with the full List of Drops!", hidden=True)
+  except:
+    await ctx.reply(embed=embed, hidden=True)
 
 
 # slash_drop() - Entrypoint for /drops command


### PR DESCRIPTION
Whoops. 😅 

If we run into an error trying to send the DM with the drops list to the user, send it as an ephemeral reply in the channel instead!