### PR TITLE
#24: Provide @check_channel_access decorator util for resticting slash commands to channels

### DIFF
--- a/commands/drop.py
+++ b/commands/drop.py
@@ -52,11 +52,6 @@ async def slash_drops(ctx:SlashContext):
 )
 @check_channel_access(command_config)
 async def slash_drop(ctx:SlashContext, query:str):
-  # Check if we're allowed to drop in this channel
-  # channel_access = await check_channel_access(ctx, command_config)
-  # if not channel_access:
-  #   return
-
   q = query.lower().strip()
 
   drop_allowed = await check_timekeeper(ctx)

--- a/commands/drop.py
+++ b/commands/drop.py
@@ -1,11 +1,11 @@
-from .common import *
+from utils.check_channel_access import *
 
-f = open(config["commands"]["drop"]["data"])
+command_config = config["commands"]["drop"]
+
+# Load JSON Data
+f = open(command_config["data"])
 drop_data = json.load(f)
 f.close()
-
-fuzz_threshold = 72
-punct_regex = r'[' + string.punctuation + ']'
 
 # drop() - Entrypoint for !drop command
 # This now just informs the channel that they can use the slash command instead
@@ -51,12 +51,10 @@ async def slash_drops(ctx:SlashContext):
   ]
 )
 async def slash_drop(ctx:SlashContext, query:str):
-  # Verify that we're allowed to perform drops in this channel
-  allowed_channels = config["commands"]["drop"]["channels"]
-  if not (ctx.channel.id in allowed_channels):
-    await ctx.send("<:ezri_frown_sad:757762138176749608> Sorry! Drops are not allowed in this channel. Please try elsewhere.", hidden=True)
+  # Check if we're allowed to drop in this channel
+  channel_access = await check_channel_access(ctx, command_config)
+  if not channel_access:
     return
-
 
   q = query.lower().strip()
 
@@ -72,6 +70,7 @@ async def slash_drop(ctx:SlashContext, query:str):
 
 # get_drop_metadata() - Logic to try to fuzzy-match user query to a drop
 # query[required] - String
+fuzz_threshold = 72
 def get_drop_metadata(query):
   query = strip_punctuation(query)
 
@@ -135,5 +134,6 @@ def set_timekeeper(ctx:SlashContext):
 
 
 # Utility Functions
+punct_regex = r'[' + string.punctuation + ']'
 def strip_punctuation(string):
   return re.sub(punct_regex, '', string).lower().strip()

--- a/commands/drop.py
+++ b/commands/drop.py
@@ -50,11 +50,12 @@ async def slash_drops(ctx:SlashContext):
     )
   ]
 )
+@check_channel_access(command_config)
 async def slash_drop(ctx:SlashContext, query:str):
   # Check if we're allowed to drop in this channel
-  channel_access = await check_channel_access(ctx, command_config)
-  if not channel_access:
-    return
+  # channel_access = await check_channel_access(ctx, command_config)
+  # if not channel_access:
+  #   return
 
   q = query.lower().strip()
 

--- a/utils/check_channel_access.py
+++ b/utils/check_channel_access.py
@@ -1,7 +1,7 @@
 from commands.common import *
 
 # @check_channel_access decorator
-# Can be injected in between @slash.slash and your drop function to 
+# Can be injected in between @slash.slash and your slash function to 
 # restrict access to the "channels" from the command config
 def check_channel_access(command_config):
   # Container accepts the actual drop function as `command`

--- a/utils/check_channel_access.py
+++ b/utils/check_channel_access.py
@@ -1,8 +1,26 @@
-from calendar import c
 from commands.common import *
 
-async def check_channel_access(ctx, command_config):
-  logger.info("Checking Channel Access")
+# @check_channel_access decorator
+# Can be injected in between @slash.slash and your drop function to 
+# restrict access to the "channels" from the command config
+def check_channel_access(command_config):
+  # Container accepts the actual drop function as `command`
+  def container(command):
+    # The decorator is what actually performs the check before determining whether to execute the command
+    async def decorator(*dargs, **dkwargs):
+      # First argument sent to the decorator is the Slash Context we need for the channel check
+      ctx = dargs[0]
+      has_channel_access = await perform_channel_check(ctx, command_config)
+      if (has_channel_access):
+        # If we have access, go ahead and execute the command and pass through the arguments sent to the decorator
+        await command(*dargs, **dkwargs)
+      else:
+        # No-Op
+        return
+    return decorator
+  return container
+
+async def perform_channel_check(ctx, command_config):
   # Verify that we're allowed to perform drops in this channel
   allowed_channels = command_config["channels"]
   if not (ctx.channel.id in allowed_channels):

--- a/utils/check_channel_access.py
+++ b/utils/check_channel_access.py
@@ -1,0 +1,16 @@
+from calendar import c
+from commands.common import *
+
+async def check_channel_access(ctx, command_config):
+  logger.info("Checking Channel Access")
+  # Verify that we're allowed to perform drops in this channel
+  allowed_channels = command_config["channels"]
+  if not (ctx.channel.id in allowed_channels):
+    allowed_channel_names = []
+    for id in allowed_channels:
+      channel = client.get_channel(id)
+      allowed_channel_names.append(channel.mention)
+    await ctx.send("<:ezri_frown_sad:757762138176749608> Sorry! Drops are not allowed in this channel. Allowed channels are: {}.".format(", ".join(allowed_channel_names)), hidden=True)
+    return False
+  else:
+    return True


### PR DESCRIPTION
Welp, after **MUCH** gnashing of teeth and a lot of "trying stuff out", I finally got a decorator working that we can use to inject between the @slash.slash decorator and a slash function to restrict a command to a specific set of channels.

As an additional improvement, if you attempt to use the command in a channel where it's not allowed it will now helpfully tell the user which channels it _can_ be used in.

Rather than passing the entire config around, I've just extracted the drop config section itself into a variable at the top of `drop.py` so that we can use that for the check as well as the other places it's used in here. Also did a small amount of general re-organizing.

w00t. 🎉 