### PR TITLE
Feature: Get Next Episode info through /nexttrek and /nextep

### DIFF
--- a/commands/nextep.py
+++ b/commands/nextep.py
@@ -8,7 +8,7 @@ from utils.check_channel_access import *
 
 # nexttrek() - Entrypoint for /nexttrek command
 # Retrieve the next Trek episode, or next episode for a specific show
-command_config = config["commands"]["nexttrek"]
+nexttrek_config = config["commands"]["nexttrek"]
 
 @slash.slash(
   name="nexttrek",
@@ -41,7 +41,7 @@ command_config = config["commands"]["nexttrek"]
     )
   ]
 )
-@check_channel_access(command_config)
+@check_channel_access(nexttrek_config)
 async def nexttrek(ctx:SlashContext, show:str):
   tvmaze_ids = {
     "lowerdecks": 39323,
@@ -67,7 +67,7 @@ async def nexttrek(ctx:SlashContext, show:str):
 
 # nextep() - Entrypoint for /nextep command
 # Retrieve the next episode of any given show query
-command_config = config["commands"]["nextep"]
+nextep_config = config["commands"]["nextep"]
 
 @slash.slash(
   name="nextep",
@@ -82,7 +82,7 @@ command_config = config["commands"]["nextep"]
     )
   ]
 )
-@check_channel_access(command_config)
+@check_channel_access(nextep_config)
 async def nextep(ctx:SlashContext, query:str):
   encoded_query = urllib.parse.quote(query, safe='')
   try:

--- a/commands/nextep.py
+++ b/commands/nextep.py
@@ -1,0 +1,144 @@
+import re
+import requests
+import urllib.parse
+
+from .common import *
+from utils.check_channel_access import *
+
+
+# nexttrek() - Entrypoint for /nexttrek command
+# Retrieve the next Trek episode, or next episode for a specific show
+command_config = config["commands"]["nexttrek"]
+
+@slash.slash(
+  name="nexttrek",
+  description="Retrieve info on the next Trek episode!",
+  guild_ids=config["guild_ids"],
+    options=[
+      create_option(
+        name="show",
+        description="Which show?",
+        required=True,
+        option_type=3,
+        choices=[
+          create_choice(
+            name="Lower Decks",
+            value="lowerdecks"
+          ),
+          create_choice(
+            name="Picard",
+            value="picard"
+          ),
+          create_choice(
+            name="Prodigy",
+            value="prodigy"
+          ),
+          create_choice(
+            name="Strange New Worlds",
+            value="snw"
+          )
+        ]
+    )
+  ]
+)
+@check_channel_access(command_config)
+async def nexttrek(ctx:SlashContext, show:str):
+  tvmaze_ids = {
+    "lowerdecks": 39323,
+    "picard": 42193,
+    "prodigy": 49333,
+    "snw": 48090,
+  }
+  show_id = tvmaze_ids.get(show)
+  try:
+    show_data = requests.get(f"https://api.tvmaze.com/shows/{show_id}").json()
+    show_name = show_data["name"]
+    next_episode = show_data["_links"].get("nextepisode")
+    if (next_episode == None):
+      await ctx.send(f"<:ezri_frown_sad:757762138176749608> Sorry, doesn't look like we have info scheduled for the next episode of {show_name}.", hidden=True)
+    else:
+      episode_data = requests.get(next_episode["href"]).json()
+      embed = await get_show_embed(show_data, episode_data)
+      await ctx.send(embed=embed)
+  except BaseException as err:
+    logger.error(err)
+    await ctx.send("<a:emh_doctor_omg_wtf_zoom:865452207699394570> Sorry, something went wrong with the request!", hidden=True)
+
+
+# nextep() - Entrypoint for /nextep command
+# Retrieve the next episode of any given show query
+command_config = config["commands"]["nextep"]
+
+@slash.slash(
+  name="nextep",
+  description="Retrieve info on the next episode of a given show!",
+  guild_ids=config["guild_ids"],
+    options=[
+      create_option(
+        name="query",
+        description="Which show?",
+        required=True,
+        option_type=3,
+    )
+  ]
+)
+@check_channel_access(command_config)
+async def nextep(ctx:SlashContext, query:str):
+  encoded_query = urllib.parse.quote(query, safe='')
+  try:
+    show_lookup = requests.get(f"https://api.tvmaze.com/singlesearch/shows?q={encoded_query}")
+    if show_lookup.status_code == 404:
+      await ctx.send("<a:emh_doctor_omg_wtf_zoom:865452207699394570> Sorry, no show matches your query!", hidden=True)
+      return
+
+    show_data = show_lookup.json()
+    show_name = show_data["name"]
+    next_episode = show_data["_links"].get("nextepisode")
+    if (next_episode == None):
+      await ctx.send(f"<:ezri_frown_sad:757762138176749608> Sorry, doesn't look like we have info scheduled for the next episode of {show_name}.", hidden=True)
+    else:
+      episode_data = requests.get(next_episode["href"]).json()
+      embed = await get_show_embed(show_data, episode_data)
+      await ctx.send(embed=embed)
+  except BaseException as err:
+    logger.error(err)
+    await ctx.send("<a:emh_doctor_omg_wtf_zoom:865452207699394570> Sorry, something went wrong with the request!", hidden=True)
+
+
+async def get_show_embed(show_data, episode_data):
+  show_name = show_data["name"]
+  # Embed Template
+  embed = discord.Embed(
+    title=f"Next episode for {show_name}",
+    color=discord.Color.blue()
+  )
+  embed.set_thumbnail(url=show_data["image"]["medium"])
+  # Summary (Remove HTML tags)
+  # Title
+  embed.add_field(
+    name="Title",
+    value=episode_data['name'],
+    inline=False
+  )
+  summary = re.sub('<[^<]+?>', '', episode_data["summary"])
+  embed.add_field(
+    name="Summary",
+    value=summary,
+    inline=False
+  )
+  # Number
+  season_number = episode_data["season"]
+  episode_number = episode_data["number"]
+  episode_number = f"Season {season_number}, Episode {episode_number}"
+  embed.add_field(
+    name="Episode Number",
+    value=episode_number,
+    inline=True
+  )
+  # Airdate
+  embed.add_field(
+    name="Airdate",
+    value=episode_data["airdate"],
+    inline=True
+  )
+  return embed

--- a/configuration.json
+++ b/configuration.json
@@ -79,6 +79,18 @@
       "data": null,
       "parameters": []
     },
+    "nextep": {
+      "channels": [780914078495014942, 771081846997123092],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
+    "nexttrek": {
+      "channels": [780914078495014942],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
     "ping": {
       "channels": [897126055289159711],
       "enabled": true,

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from commands.info import info
 from commands.jackpot import jackpot, jackpots
 from commands.migrate import migrate
 from commands.nasa import nasa
+from commands.nextep import nexttrek, nextep
 from commands.poker import *
 from commands.ping import ping
 from commands.profile import profile


### PR DESCRIPTION
Heyo. One of the bots we have in the IRC where I hangout has a similar command to this and I thought I'd try replicating it for the FoDBot with a little nice wrapper splash around `/nexttrek`

This queries the tvmaze.com API to look for information on a show's next episode, and then presents it nicely to the context in an embed so people can quickly look up info on what's coming up next.

`/nextep` does a general query to try to find the next episode of _any_ show and post the info.

`/nexttrek` does the same but has an interface wrapper that limits the query to the currently airing Trek shows and presents the four (current) options to the user with the specific show IDs already set up to ensure they always get a good match.

I've got the default `configuration.json` set up so that `/nexttrek` is available in both "#generaltrek" and "#ancient-human-visual-media", while `/nextep` is just available in "#ancient-human-visual-media"

### In Action
#### /nexttrek
![Screen Shot 2022-05-19 at 3 12 27 PM](https://user-images.githubusercontent.com/1075211/169417360-d88fd30e-5fa2-4907-ae06-f095a78633d5.png)

![Screen Shot 2022-05-19 at 3 12 13 PM](https://user-images.githubusercontent.com/1075211/169417371-6e177fd2-da9a-43ac-b586-d1454e800b0a.png)

#### /nextep
![Screen Shot 2022-05-19 at 3 43 06 PM](https://user-images.githubusercontent.com/1075211/169417394-248704a3-22bf-4b5a-9ffe-626f9c1e7bfc.png)

Let me know what you think and if this might be a nice addition to the bot!