### PR TITLE
Feat: Listen for Reacts, Grant XP For Very Reaction-Worthy Messages

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -251,11 +251,14 @@
   "intro_channel" : 757754485790736504,
   "logging_channel" : 987781132214992956,
   "emojis": {
+    "data_lmao_lol": "<:data_lmao_lol:757762906556203050>",
     "emh_doctor_omg_wtf_zoom": "<a:emh_doctor_omg_wtf_zoom:865452207699394570>",
     "ezri_frown_sad": "<:ezri_frown_sad:757762138176749608>",
     "guinan_beanflick_stance_threat": "<:guinan_beanflick_stance_threat:760216477235281942>",
     "louvois_point_yes": "<:louvois_point_yes:840252104056766515>",
+    "picard_yes_happy_celebrate": "<:picard_yes_happy_celebrate:757726753346027622>",
     "ohno": "<:ohno:930365904657723402>",
-    "tendi_smile_happy": "<:tendi_smile_happy:757768236069814283>"
+    "tendi_smile_happy": "<:tendi_smile_happy:757768236069814283>",
+    "tgg_love_heart": "<:love_heart_tgg:798600300264161280>"
   }
 }

--- a/main.py
+++ b/main.py
@@ -173,5 +173,17 @@ async def on_ready():
   
   logger.info("BOT STARTED AND LISTENING FOR COMMANDS!!!")
 
+@client.event
+async def on_reaction_add(reaction, user):
+  # If someone made a particularly reaction-worthy message, award them some XP!
+  relevant_emojis = [
+    config["emojis"]["data_lmao_lol"],
+    config["emojis"]["picard_yes_happy_celebrate"],
+    config["emojis"]["tgg_love_heart"]
+  ]
+  if f"{reaction.emoji}" in relevant_emojis and reaction.count >= 5:
+    increment_user_xp(reaction.message.author.id, 1)
+
+
 # Engage!
 client.run(DISCORD_TOKEN)


### PR DESCRIPTION
Toying with this idea of listening for reactions to messages and granting a little extra XP if someone posted something particularly reaction-worthy.

Right now this just grants an extra +1 XP for every reaction of that type above 5. We _could_ create some kind of table and only grant the XP _once_ after they hit 5 but I'm not sure if that's necessary and maybe they should just be rewarded for each one after the threshold?