### PR TITLE
Feat: New React XP Bonuses + Prevent Users From Gaming The System

### DIFF
--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -25,3 +25,13 @@ CREATE TABLE IF NOT EXISTS users (
   PRIMARY KEY (id),
   UNIQUE KEY (discord_id)
 );
+CREATE TABLE IF NOT EXISTS reactions (
+  id int(11) NOT NULL AUTO_INCREMENT,
+  user_id varchar(64) NOT NULL,
+  user_name varchar(64) NOT NULL,
+  reaction varchar(128) NOT NULL,
+  reaction_message_id varchar(64) NOT NULL,
+  time_created timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (id),
+  CONSTRAINT USERID_MESSAGEID UNIQUE (user_id, reaction_message_id)
+);

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ from commands.trekduel import trekduel
 from commands.trektalk import trektalk
 from commands.tuvix import tuvix
 from commands.update_status import update_status
-from commands.xp import handle_message_xp, increment_user_xp
+from commands.xp import handle_message_xp, handle_react_xp
 from utils.check_channel_access import perform_channel_check
 
 logger.info(f"{Fore.LIGHTGREEN_EX}ENVIRONMENT VARIABLES AND COMMANDS LOADED{Fore.RESET}")
@@ -152,15 +152,7 @@ async def on_ready():
 # listen to reactions
 @client.event
 async def on_reaction_add(reaction, user):
-  # If someone made a particularly reaction-worthy message, award them some XP!
-  relevant_emojis = [
-    config["emojis"]["data_lmao_lol"],
-    config["emojis"]["picard_yes_happy_celebrate"],
-    config["emojis"]["tgg_love_heart"]
-  ]
-  if f"{reaction.emoji}" in relevant_emojis and reaction.count >= 5:
-    logger.info(f"User {Style.BRIGHT}{reaction.message.author}{Style.RESET_ALL} gets {Style.BRIGHT}1 xp{Style.RESET_ALL} for their post being reacted to!")
-    increment_user_xp(reaction.message.author, 1)
+  await handle_react_xp(reaction, user)
 
 
 # Engage!


### PR DESCRIPTION
### New XP bonuses for reacts!

Moved all of the XP stuff from `on_reaction_add()` into `xp.py` with `handle_react_xp()`

All users get **1 xp** for reacting to a message.

The author gets the following XP bonuses depending on how reaction-worthy their message is:
* **+1xp** for each relevant react above 5.
* **+2xp** (total) for each relevant react above 10.
* **+5xp** (total) for each relevant react above 20.

### Do Not Try To Cheat AGIMUS!
If a user toggles off their react and toggles it back on, we no longer continue to count those as new reacts. There's a new DB table `reactions` that handles this logging.

![image](https://user-images.githubusercontent.com/1075211/174680072-586e5989-f81a-4e08-815c-7518805a2924.png)
