### PR TITLE
Fix: Correct Cadet/Ensign Names With Pips

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -584,8 +584,8 @@
         "ensign": 16
       },
       "ranks": {
-        "cadet": "Cadet",
-        "ensign": "Ensign"
+        "cadet": "Cadet ○",
+        "ensign": "Ensign ●"
       },
       "enabled": true
     }

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -69,6 +69,9 @@ async def handle_message_xp(message:discord.Message):
       if cadet_role in guild_role_names and ensign_role in guild_role_names:
         await handle_intro_channel_promotion(message)
         await handle_rank_xp_promotion(message, xp_amt)
+      else:
+        logger.info(f"Promotion is enabled but {Fore.CYAN}Cadet{Fore.RESET} and role {Fore.CYAN}Ensign{Fore.RESET} roles are not available from the guild!")
+        logger.info(f"Available roles are: {Style.BRIGHT}{guild_role_names}{Style.RESET_ALL}.")
 
 
 # If this message is in the intro channel, handle their auto-promotion


### PR DESCRIPTION
Also added just a touch more logging in the case where the XP Promotions are enabled but the Cadet/Ensign roles are not found in the guild roles.