### PR TITLE
Skip unit conversions on times

### DIFF
--- a/handlers/unit_conversion.py
+++ b/handlers/unit_conversion.py
@@ -3,6 +3,8 @@ from commands.common import *
 from quantulum3 import parser
 from pint import UnitRegistry
 
+import re
+
 ureg = UnitRegistry()
 uQ = ureg.Quantity
 emojis = config["emojis"]
@@ -14,6 +16,9 @@ def format_trailing(value):
 async def handle_mentioned_units(message:discord.Message):
 
   if message.author.bot or message.content.startswith('http'):
+    return
+
+  if re.search('([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?( ?[AaPp][Mm])?', message.content) != None:
     return
 
   quants = parser.parse(message.content)
@@ -130,4 +135,4 @@ async def handle_mentioned_units(message:discord.Message):
         continue
 
     if embed.description:
-      logger.info(f"Unit conversion for {Style.BRIGHT}{message.author.display_name}{Style.NORMAL} in #{Style.BRIGHT}{message.channel.name}{Style.NORMAL}! {Fore.LIGHTBLUE_EX}WOLOLOLOLOLO{Fore.RESET}")  
+      logger.info(f"Unit conversion for {Style.BRIGHT}{message.author.display_name}{Style.NORMAL} in #{Style.BRIGHT}{message.channel.name}{Style.NORMAL}! {Fore.LIGHTBLUE_EX}WOLOLOLOLOLO{Fore.RESET}")


### PR DESCRIPTION
If a message is received by the bot like "6:40 AM", the bot currently
sees this as 40 annometers even though it's clearly a time.  This
updates the bot to not convert times then they're found.

Here is a test of the regex: https://regexr.com/6ocfi

Fixes #81