### PR TITLE
Refactor: Move Unit Conversion to Slash Command

### DIFF
--- a/commands/convert.py
+++ b/commands/convert.py
@@ -1,0 +1,103 @@
+from quantulum3 import parser
+from pint import UnitRegistry
+import re
+
+from .common import *
+from utils.check_channel_access import *
+
+ureg = UnitRegistry()
+Q_ = ureg.Quantity
+
+command_config = config["commands"]["convert"]
+emojis = config["emojis"]
+
+# Load JSON Data
+f = open(command_config["data"])
+convert_data = json.load(f)
+f.close()
+
+
+@slash.slash(
+  name="convert",
+  description="Convert an Imperial or Metric unit to its counterpart!",
+  guild_ids=config["guild_ids"],
+  options=[
+    create_option(
+      name="conversion",
+      description="What conversion unit would you like? Example: 10km",
+      required=True,
+      option_type=3
+    ),
+    create_option(
+      name="private",
+      description="Send clip to just yourself?",
+      required=False,
+      option_type=5,
+    )
+  ]
+)
+@slash_check_channel_access(command_config)
+async def convert(ctx:SlashContext, **kwargs):
+  conversion = kwargs.get('conversion')
+  private = kwargs.get('private')
+
+  if re.search('([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?( ?[AaPp][Mm])?', conversion) != None:
+    time_embed = discord.Embed(
+      title="Sorry, unable to convert times!",
+      color=discord.Color.greyple()
+    )
+    await ctx.send(embed=time_embed, hidden=True)
+    return
+
+  found_minimum_match = False
+  quants = parser.parse(conversion)
+  if quants:
+    for quant in quants:
+      value = quant.value
+      unit_name = quant.unit.name.lower()
+
+      # logger.info(f"(value: {value}, unit_name: {unit_name})")
+
+      # Unit parser sometimes catches some units we do not want to convert
+      # an NFT = "newton foot" for example
+      # So ignore the following list
+      for partial in ['cubic', 'deci', 'deka', 'hecto', 'exa', 'newton']:
+        if partial in unit_name:
+          continue
+
+      embed = discord.Embed(color=discord.Color.greyple())
+
+      units = convert_data["units"]
+      for unit_key in units:
+        unit = units[unit_key]
+        unit_names = unit_name.split()
+        if any(x in unit_names for x in unit["matches"]) and not any(x in unit_names for x in unit["ignored_matches"]):
+          converted_value = Q_(value, unit_key)
+          embed.description = f"{format_trailing(value)} {unit['plural']} is {'{:.2f}'.format(converted_value.to(unit['convert_to']).magnitude)} {unit['convert_to_plural']}!"
+          await ctx.send(embed=embed, hidden=private)
+          found_minimum_match = True
+
+      # Special casing for stone -> kilograms
+      pound_match = re.match("(\d+.?\d+?) stone", conversion)
+      if pound_match:
+        value = pound_match.groups()[0]
+        pound_value = int(value) * 14
+        pounds = pound_value * ureg.pound
+        embed.description = f"{format_trailing(value)} stone is {'{:.2f}'.format(pounds.to('kilogram').magnitude)} kilograms!"
+        await ctx.send(embed=embed, hidden=public)
+        found_minimum_match = True
+
+      if embed.description:
+        logger.info(f"Unit conversion for {Style.BRIGHT}{ctx.author.display_name}{Style.NORMAL} in #{Style.BRIGHT}{ctx.channel.name}{Style.NORMAL}! {Fore.LIGHTBLUE_EX}WOLOLOLOLOLO{Fore.RESET}")
+
+      continue
+
+  if not found_minimum_match:
+    await ctx.send(embed=discord.Embed(
+      title="No supported unit match found!",
+      color=discord.Color.dark_red()
+    ), hidden=True)
+    return
+
+def format_trailing(value):
+  return re.sub('\.0$', '', f"{value}")

--- a/commands/convert.py
+++ b/commands/convert.py
@@ -78,7 +78,7 @@ async def convert(ctx:SlashContext, **kwargs):
           found_minimum_match = True
 
       # Special casing for stone -> kilograms
-      pound_match = re.match("(\d+.?\d+?) stone", conversion)
+      pound_match = re.search("(\d+.?\d+?) stone", conversion)
       if pound_match:
         value = pound_match.groups()[0]
         pound_value = int(value) * 14

--- a/configuration.json
+++ b/configuration.json
@@ -81,6 +81,12 @@
       "parameters": [],
       "error_contact_id": 735658100958298154
     },
+    "convert": {
+      "channels": [],
+      "enabled": true,
+      "data": "data/conversions.json",
+      "parameters": []
+    },
     "dustbuster": {
       "channels": [
         "conversation-booth"

--- a/data/conversions.json
+++ b/data/conversions.json
@@ -1,0 +1,134 @@
+{
+  "units": {
+    "liter": {
+      "matches": [
+        "litre"
+      ],
+      "ignored_matches": [
+        "millilitre"
+      ],
+      "plural": "liters",
+      "convert_to": "gallon",
+      "convert_to_plural": "gallons"
+    },
+    "gallon": {
+      "matches": [
+        "gallon"
+      ],
+      "ignored_matches": [],
+      "plural": "gallons",
+      "convert_to": "liter",
+      "convert_to_plural": "liters"
+    },
+    "mile": {
+      "matches": [
+        "mile"
+      ],
+      "ignored_matches": [],
+      "plural": "miles",
+      "convert_to": "kilometer",
+      "convert_to_plural": "kilometers"
+    },
+    "kilometer": {
+      "matches": [
+        "kilometre"
+      ],
+      "ignored_matches": [],
+      "plural": "kilometers",
+      "convert_to": "mile",
+      "convert_to_plural": "miles"
+    },
+    "inch": {
+      "matches": [
+        "inch"
+      ],
+      "ignored_matches": [],
+      "plural": "inches",
+      "convert_to": "centimeter",
+      "convert_to_plural": "centimeters"
+    },
+    "centimeter": {
+      "matches": [
+        "centimetre"
+      ],
+      "ignored_matches": [],
+      "plural": "centimeters",
+      "convert_to": "inch",
+      "convert_to_plural": "inches"
+    },
+    "foot": {
+      "matches": [
+        "foot"
+      ],
+      "ignored_matches": [],
+      "plural": "feet",
+      "convert_to": "meter",
+      "convert_to_plural": "meters"
+    },
+    "meter": {
+      "matches": [
+        "metre"
+      ],
+      "ignored_matches": [],
+      "plural": "meters",
+      "convert_to": "foot",
+      "convert_to_plural": "feet"
+    },
+    "pound-mass": {
+      "matches": [
+        "pound-mass"
+      ],
+      "ignored_matches": [],
+      "plural": "pounds",
+      "convert_to": "kilogram",
+      "convert_to_plural": "kilograms"
+    },
+    "kilogram": {
+      "matches": [
+        "kilogram"
+      ],
+      "ignored_matches": [],
+      "plural": "kilograms",
+      "convert_to": "pound-mass",
+      "convert_to_plural": "pounds"
+    },
+    "ounce": {
+      "matches": [
+        "ounce"
+      ],
+      "ignored_matches": [],
+      "plural": "ounces",
+      "convert_to": "gram",
+      "convert_to_plural": "grams"
+    },
+    "gram": {
+      "matches": [
+        "gram"
+      ],
+      "ignored_matches": [],
+      "plural": "grams",
+      "convert_to": "ounce",
+      "convert_to_plural": "ounces"
+    },
+    "fahrenheit": {
+      "matches": [
+        "fahrenheit",
+        "farad"
+      ],
+      "ignored_matches": [],
+      "plural": "Fahrenheit",
+      "convert_to": "celsius",
+      "convert_to_plural": "Celsius"
+    },
+    "celsius": {
+      "matches": [
+        "celsius",
+        "centavo"
+      ],
+      "ignored_matches": [],
+      "plural": "Celsius",
+      "convert_to": "fahrenheit",
+      "convert_to_plural": "Fahrenheit"
+    }
+  }
+}

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from commands.buy import buy
 from commands.categories import categories
 from commands.clear_media import clear_media
 from commands.clip import clip, clips
+from commands.convert import convert
 from commands.dustbuster import dustbuster
 from commands.drop import drop, slash_drop, slash_drops
 from commands.fmk import fmk
@@ -34,7 +35,6 @@ from commands.server_logs import show_leave_message, show_nick_change_message
 # Handlers
 from handlers.alerts import handle_alerts
 from handlers.bot_autoresponse import handle_bot_affirmations
-from handlers.unit_conversion import handle_mentioned_units
 from handlers.xp import handle_message_xp, handle_react_xp
 # Tasks
 from tasks.scheduler import Scheduler
@@ -61,7 +61,6 @@ async def on_message(message:discord.Message):
   # Special message Handlers
   try:
     await handle_bot_affirmations(message)
-    await handle_mentioned_units(message)
     await handle_alerts(message)
   except Exception as e:
     logger.error(f"{Fore.RED}<! ERROR: Encountered error in handlers !> {e}{Fore.RESET}")


### PR DESCRIPTION
Bunch of refactoring and moving the code around. Bot no longer parses all messages but users can use `/convert` to get the same functionality.

Converted units can be defined in `data/conversions.json` now rather than doing a series of if statements.